### PR TITLE
Allow multiple (>2) streams

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,10 +9,10 @@ var JSONStream = require('JSONStream')
 run()
 
 function run() {
-  if (!process.argv[2] || !process.argv[3]) return console.error('Usage: json-merge <source1> <source2>')
-  var first = getStream(process.argv[2])
-  var second = getStream(process.argv[3])
-  var merger = merge(first, second)
+  if (!process.argv[2] || !process.argv[3])
+    return console.error('Usage: json-merge <source1> <source2> [<source3>...]')
+  var streams = process.argv.splice(2).map(getStream);
+  var merger = merge(streams)
   merger.pipe(ldj.serialize()).pipe(process.stdout)
 }
 

--- a/foobar.json
+++ b/foobar.json
@@ -6,6 +6,9 @@
       },
       "b": {
         "ALL": "CAPS"
+      },
+      "c": {
+        "All": "Propercase"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // var through = require('through2')
 var merge = require('merge-object-streams')
 
-module.exports = function(first, second) {
-  return new merge([first, second])
+module.exports = function(streams) {
+  return new merge(streams)
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "cat foobar.json | json-merge \"data.*.a\" \"data.*.b\""
+    "test": "cat foobar.json | json-merge \"data.*.a\" \"data.*.b\" \"data.*.c\""
   },
   "author": "max ogden",
   "license": "BSD",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # json-merge
 
-given two streams of newline delimited JSON data perform a merge/extend on each object in the stream
+given multiple streams of newline delimited JSON data perform a merge/extend on each object in the stream
 
 [![NPM](https://nodei.co/npm/json-merge.png?global=true)](https://nodei.co/npm/json-merge/)
 ![dat](http://img.shields.io/badge/Development%20sponsored%20by-dat-green.svg?style=flat)
@@ -9,7 +9,7 @@ given two streams of newline delimited JSON data perform a merge/extend on each 
 
 ```
 npm install json-merge -g
-json-merge <source1> <source2>
+json-merge <source1> <source2> [<source3>...]
 ```
 
 sources can be one of 3 things:


### PR DESCRIPTION
Hey,

since `merge-object-streams` allows more than 2 streams, I thought I generalize this tool, too. The old examples with 2 streams of course still work. Also it makes a nice use of the `map` function :dancer: 

Best,
Finn
